### PR TITLE
Use PropTypes from `prop-types`

### DIFF
--- a/src/Loop.jsx
+++ b/src/Loop.jsx
@@ -28,7 +28,7 @@ export const Loop = ({ items, primaryKey, destructure, indexKey, itemKey, childr
 };
 
 Loop.propTypes = {
-  items: React.PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.object, PropTypes.string])).isRequired,
+  items: PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.object, PropTypes.string])).isRequired,
   primaryKey: PropTypes.string,
   itemKey: PropTypes.string,
   indexKey: PropTypes.string,


### PR DESCRIPTION
since i got this:

Warning: PropTypes has been moved to a separate package. 
Accessing React.PropTypes is no longer supported and will be removed completely in React 16. 
Use the prop-types package on npm instead. (https://fb.me/migrating-from-react-proptypes)